### PR TITLE
New versions of markdown problematic, set to 2.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.5.4
-South
+South==0.7.6
 pytz
 django-dynamicresponse
 wsgiref
@@ -22,7 +22,7 @@ django-crispy-forms==1.3.1
 django-localflavor-us
 pycrypto
 django-fields==0.2.1
-markdown
+markdown==2.3.1
 django-markup
 django-widgeter
 feedparser


### PR DESCRIPTION
Also, preemptively add the South version currently on our production server.  Ideally we should add versions for all of our libraries.
