### PR TITLE
collectstatic has issues with ply==3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ xlrd
 python-memcached
 django-ordered-model
 django-pipeline==1.3.11
-slimit
+slimit==0.8.1
+ply==3.4
 django-cache-tools
 django-haystack
 pyelasticsearch

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ django-markup
 django-widgeter
 feedparser
 django-mptt
+requests==2.0.1


### PR DESCRIPTION
ply is required by slimit.  collectstatic throws the following error when ply==3.6 is installed:

`TypeError: argument of type 'module' is not iterable`

Reverting to ply==3.4 corrects the issue.
